### PR TITLE
Reinstall signal handler

### DIFF
--- a/src/debugger/awinch.c
+++ b/src/debugger/awinch.c
@@ -25,6 +25,7 @@ volatile int aw_layout_changed;
 // -----------------------------------------------------------------------
 static void _aw_sigwinch_handler(int signum)
 {
+	signal(SIGWINCH, _aw_sigwinch_handler);
 	aw_layout_changed = 1;
 }
 

--- a/src/debugger/debugger.c
+++ b/src/debugger/debugger.c
@@ -64,6 +64,7 @@ void yy_delete_buffer(YY_BUFFER_STATE b);
 // -----------------------------------------------------------------------
 static void _dbg_sigint_handler(int signum)
 {
+	signal(SIGINT, _dbg_sigint_handler);
 	dbg_enter = 1;
 }
 


### PR DESCRIPTION
SysV semantics in Linux signal(2) seems to imply SA_RESETHAND therefore we
should reinstate the signal handler whenever it is called, as our signal
handlers are re-entrant.

We still have a problem when using BSD signal(2) semantics (SA_RESTART) imply
restart the system calls if not asked otherwise.
