### PR TITLE
cmake build improvements: dependency paths

### DIFF
--- a/include/log.h
+++ b/include/log.h
@@ -18,6 +18,8 @@
 #ifndef LOG_H
 #define LOG_H
 
+#define _WITH_DPRINTF
+#include <stdio.h>
 #include <inttypes.h>
 
 #include "cfg.h"
@@ -86,8 +88,10 @@ void log_config(unsigned component, unsigned level, struct cfg_em400 *cfg);
 #endif
 
 #define LOG_SET_ID(object, format, ...) \
-	snprintf((object)->LOG_ID_NAME, LOG_ID_LEN, format, ##__VA_ARGS__); \
-	(object)->LOG_ID_NAME[LOG_ID_LEN] = '\0'
+	snprintf((object)->LOG_ID_NAME, \
+		sizeof((object)->LOG_ID_NAME), \
+		format, ##__VA_ARGS__); \
+	(object)->LOG_ID_NAME[sizeof((object)->LOG_ID_NAME) - 1] = '\0'
 
 #define LOG_GET_ID(object) \
 	(object)->LOG_ID_NAME

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,13 @@ add_executable(emitool
 	emitool.c io/dev/e4image.c
 )
 
+include_directories(
+	${EMDAS_INCLUDE_DIRS}
+	${EMCRK_INCLUDE_DIRS}
+	${EMAWP_INCLUDE_DIRS}
+	${FLEX_INCLUDE_DIRS}
+	${BISON_INCLUDE_DIRS}
+)
 target_link_libraries(em400
 	cpu mem io ui ectl
 	${DEBUGGER_LIBS}

--- a/src/io/mx.c
+++ b/src/io/mx.c
@@ -15,8 +15,9 @@
 //  Foundation, Inc.,
 //  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 
+#include <sys/cdefs.h>
 #include <stdlib.h>
 #include <inttypes.h>
 #include <pthread.h>

--- a/src/log_crk.c
+++ b/src/log_crk.c
@@ -15,7 +15,7 @@
 //  Foundation, Inc.,
 //  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
-#define _XOPEN_SOURCE 500
+#define _XOPEN_SOURCE 700
 
 #include <stdlib.h>
 #include <stdio.h>

--- a/src/ui/cmd/cmd.c
+++ b/src/ui/cmd/cmd.c
@@ -16,6 +16,7 @@
 //  51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define _POSIX_C_SOURCE 200112L
+#define __BSD_VISIBLE 1 /* for INADDR_LOOPBACK */
 
 #include <stdlib.h>
 #include <stdio.h>


### PR DESCRIPTION
- actually use cmake dependency configuration
- update POSIX standards where necessary
- provide POSIX exceptions where necessary
- make sure em400 builds on FreeBSD

Dependency paths has been checked with random
installation paths using conf.sh from

  https://github.com/saper/bootstrap400